### PR TITLE
Outputing errors to separate entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For example, the above interactor acts as follows:
 
 ```ruby
 result = AuthenticateUser.call({})
-#=> #<Interactor::Context email=["email is missing"], password=["password is missing"]>
+#=> #<Interactor::Context errors={:email=>["email is missing"], :password=>["password is missing"]}>
 
 result.failure?  #=> true
 ```

--- a/lib/interactor/contracts/breach_set.rb
+++ b/lib/interactor/contracts/breach_set.rb
@@ -27,8 +27,8 @@ module Interactor
       #   end
       #
       #   result = AuthenticateUser.call({})
-      #   #=> #<Interactor::Context email=["email is missing"],
-      #                             password=["password is missing"]>
+      #   #=> #<Interactor::Context errors={:email=>["email is missing"],
+      #                                     :password=>["password is missing"]}>
       #
       #   result.failure?  #=> true
       #
@@ -36,11 +36,12 @@ module Interactor
       # @return [Hash] a hash with property keys and message values
       def to_hash
         reduce({}) do |result, (property, messages)|
-          result[property] = if messages.is_a?(Hash)
-                               messages
-                             else
-                               Array(result[property]) | messages
-                             end
+          (result[:errors] ||= {})[property] =
+            if messages.is_a?(Hash)
+              messages
+            else
+             Array(result[:errors][property]) | messages
+            end
 
           result
         end

--- a/spec/interactor/contracts/breach_set_spec.rb
+++ b/spec/interactor/contracts/breach_set_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Interactor::Contracts::BreachSet do
 
       result = set.to_hash
 
-      expect(result[:first_name]).to eq(%w(first second third))
-      expect(result[:last_name]).to eq(["last_name is missing"])
-      expect(result[:address]).to eq("line_1" => "line 1 is missing")
+      expect(result[:errors][:first_name]).to eq(%w(first second third))
+      expect(result[:errors][:last_name]).to eq(["last_name is missing"])
+      expect(result[:errors][:address]).to eq("line_1" => "line 1 is missing")
     end
   end
 end

--- a/spec/interactor/contracts/outcome_spec.rb
+++ b/spec/interactor/contracts/outcome_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Interactor::Contracts::Outcome do
       end
 
       it "converts to a hash based on its breaches" do
-        expect(subject.to_h).to eq(:name => ["name is missing"])
+        expect(subject.to_h).to eq(:errors => {:name => ["name is missing"]})
       end
     end
   end

--- a/spec/interactor/contracts_spec.rb
+++ b/spec/interactor/contracts_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Interactor::Contracts do
 
     result = interactor.call({})
     expect(result).to be_a_failure
-    expect(result.name).to eq(["name is missing"])
+    expect(result.errors[:name]).to eq(["name is missing"])
   end
 
   describe ".assures" do


### PR DESCRIPTION
instead of overriding existing context